### PR TITLE
load fontdb in query_all so that we can measure text files

### DIFF
--- a/native/resvg/src/lib.rs
+++ b/native/resvg/src/lib.rs
@@ -361,7 +361,7 @@ pub fn query_all<'a>(env: Env<'a>, in_svg: String, options: Options) -> NifResul
         usvg::Tree::from_xmltree(&xml_tree, &parsed_options.usvg).map_err(|e| e.to_string()),
         env
     );
-    
+
     // fontdb initialization is pretty expensive, so perform it only when needed.
     if tree.has_text_nodes() {
         match load_fonts(&parsed_options) {

--- a/native/resvg/src/lib.rs
+++ b/native/resvg/src/lib.rs
@@ -357,10 +357,18 @@ pub fn query_all<'a>(env: Env<'a>, in_svg: String, options: Options) -> NifResul
         env
     );
 
-    let tree = try_or_return_elixir_err!(
+    let mut tree = try_or_return_elixir_err!(
         usvg::Tree::from_xmltree(&xml_tree, &parsed_options.usvg).map_err(|e| e.to_string()),
         env
     );
+    
+    // fontdb initialization is pretty expensive, so perform it only when needed.
+    if tree.has_text_nodes() {
+        match load_fonts(&parsed_options) {
+            Ok(fontdb) => tree.convert_text(&fontdb),
+            Err(error) => return Ok((atoms::error(), error).encode(env)),
+        };
+    }
 
     fn round_len(v: f32) -> f32 {
         (v * 1000.0).round() / 1000.0

--- a/test/resvg_test.exs
+++ b/test/resvg_test.exs
@@ -171,5 +171,28 @@ defmodule Resvg.Test do
                  height: 613.6170043945312
                }
     end
+
+    test "measures text elements if the right font files are given" do
+      roboto = font_file("Roboto/Roboto-Regular.ttf")
+
+      input = image_path("text-measurement.svg")
+
+      [node] = Resvg.query_all(input, font_files: [roboto], resources_dir: @tmp)
+
+      assert node ==
+               %Resvg.Native.Node{
+                 id: "Text-Element-1",
+                 x: 0.28700000047683716,
+                 y: -8.531000137329102,
+                 width: 85.18399810791016,
+                 height: 8.64799976348877
+               }
+    end
+
+    test "doesn't measure text elements if the right font files are not given" do
+      input = image_path("text-measurement.svg")
+
+      assert Resvg.query_all(input, font_files: []) == []
+    end
   end
 end

--- a/test/support/text-measurement.svg
+++ b/test/support/text-measurement.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1200 800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <text id="Text-Element-1" font-family="Roboto">Text to measure</text>
+</svg>


### PR DESCRIPTION
Conditionally load the font database when calling `query_all()` so that we can measure text elements (which IMO is the most logical thing to measure with resvg). Added some tests.