### PR TITLE
fix(release-ci): replace retired runner images (unblocks precompiled NIF release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,16 +24,16 @@ jobs:
       matrix:
         nif: ["2.16", "2.15"]
         job:
-          - { target: x86_64-apple-darwin, os: macos-13 }
-          - { target: aarch64-apple-darwin, os: macos-13 }
-          - { target: arm-unknown-linux-gnueabihf, os: ubuntu-20.04, use-cross: true }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
-          - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
-          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019 }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
+          - { target: x86_64-apple-darwin, os: macos-15 }
+          - { target: aarch64-apple-darwin, os: macos-15 }
+          - { target: arm-unknown-linux-gnueabihf, os: ubuntu-22.04, use-cross: true }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true }
+          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true }
+          - { target: x86_64-pc-windows-gnu, os: windows-2022 }
+          - { target: x86_64-pc-windows-msvc, os: windows-2022 }
 
     steps:
       - name: Checkout source code


### PR DESCRIPTION
## Problem

The **Build precompiled NIFs** workflow (`release.yml`) has been unable to run. Every matrix job sits in `queued` and is eventually cancelled at GitHub's 24h ceiling — for example the `v0.6.0` tag build and the last few `master` builds never produced any artifacts. Because this workflow is what generates the precompiled NIFs, **no Hex release can be cut** until it's fixed.

## Root cause

The matrix pins GitHub-hosted runner images that GitHub has **retired**:

| Image | Status |
|-------|--------|
| `ubuntu-20.04` | retired (2025) |
| `windows-2019` | retired (2025) |
| `macos-13` | no longer available |

When a job requests a runner image that no longer exists, it is never assigned a runner — it just stays `queued` until the 24h timeout. This is why *every* job hangs, and why the `Tests` workflow is unaffected: it uses `ubuntu-latest`.

Evidence: on the `v0.6.0` run, all 20 jobs report `status: queued` with an empty `runner_name` 4+ hours in; the prior `master` release run was cancelled after exactly 24h; meanwhile the `Tests` run on the same commit (on `ubuntu-latest`) passed in ~1 min.

## Fix

Move to currently supported, **non-deprecated** images:

- `ubuntu-20.04` → `ubuntu-22.04`
- `windows-2019` → `windows-2022`
- `macos-13` → `macos-15`

Image-choice rationale (checked against GitHub's [runner-images](https://github.com/actions/runner-images) list):
- These favour the **oldest still-supported** images rather than the newest (`ubuntu-24.04` / `windows-2025` / `macos-26`), to keep precompiled artifacts broadly compatible — but deliberately avoid anything already flagged for retirement so this doesn't recur.
- **macOS: `macos-14` is currently marked *deprecated*/scheduled for retirement, so I used `macos-15`** (the current supported image; `macos-latest` points to it). `macos-15` is Apple Silicon, but both darwin targets already build with an explicit `--target`, so `x86_64-apple-darwin` cross-compiles fine (`aarch64-apple-darwin` builds natively).
- **`x86_64-unknown-linux-gnu` now builds via `cross` (`use-cross: true`).** It was the only Linux target built natively on the host, so bumping the host to `ubuntu-22.04` would have raised its glibc floor from **2.31 → 2.35**, reducing portability of the published artifact. Building it in the `cross` image keeps the glibc floor low and independent of the host image. If you'd rather keep it native on the host, happy to drop that one line.

## How to verify

Merging this to `master` touches `.github/workflows/release.yml`, which is a trigger path, so the workflow will kick off on merge. To produce the `0.6.0` artifacts you'll likely want to re-point the tag after this lands (e.g. re-tag `v0.6.0` on the new `master`, or cut `v0.6.1`) so the tag build runs with the fixed matrix.

I don't have a way to test the retired→new image swap without your Actions runners, but the change is limited to runner labels plus the one `use-cross` flag.
